### PR TITLE
security: Phase 1 hardening — secrets, headers, rate limiting, enum validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Database
+# ASP.NET Core reads this as ConnectionStrings__DefaultConnection
+ConnectionStrings__DefaultConnection=Host=localhost;Port=5432;Database=invenetdb;Username=postgres;Password=CHANGE_ME
+
+# JWT Authentication
+# Must be at least 32 characters. Generate with: openssl rand -base64 32
+Jwt__Key=CHANGE_ME_USE_A_LONG_RANDOM_SECRET_AT_LEAST_32_CHARS
+Jwt__Issuer=Invenet.Api
+Jwt__Audience=Invenet.Api
+Jwt__AccessTokenMinutes=60
+Jwt__RefreshTokenDays=1
+Jwt__RememberMeRefreshTokenDays=7
+
+# SendGrid Email
+SendGrid__ApiKey=CHANGE_ME
+SendGrid__FromEmail=noreply@yourdomain.com
+SendGrid__FromName=Invenet
+
+# CORS — comma-separated list of allowed frontend origins
+Cors__Origins__0=http://localhost:4200
+
+# Frontend base URL (used for email confirmation links)
+Frontend__Url=http://localhost:4200

--- a/apps/api/Invenet.Api/Modules/Trades/API/TradesController.cs
+++ b/apps/api/Invenet.Api/Modules/Trades/API/TradesController.cs
@@ -248,14 +248,25 @@ public sealed class TradesController : ControllerBase
       return BadRequest(new { message = "Either strategyId or strategyVersionId must be provided" });
     }
 
+    TradeStatus resolvedStatus = TradeStatus.Open;
+    if (!string.IsNullOrWhiteSpace(request.Status) &&
+        !Enum.TryParse<TradeStatus>(request.Status, ignoreCase: true, out resolvedStatus))
+    {
+      return BadRequest(new { message = $"Invalid status '{request.Status}'. Valid values: {string.Join(", ", Enum.GetNames<TradeStatus>())}" });
+    }
+
+    if (!Enum.TryParse<TradeDirection>(request.Direction, ignoreCase: true, out var resolvedDirection))
+    {
+      return BadRequest(new { message = $"Invalid direction '{request.Direction}'. Valid values: {string.Join(", ", Enum.GetNames<TradeDirection>())}" });
+    }
+
     var now = DateTime.UtcNow;
-    var resolvedStatus = string.IsNullOrWhiteSpace(request.Status) ? TradeStatus.Open : Enum.Parse<TradeStatus>(request.Status);
     var trade = new Trade
     {
       Id = Guid.NewGuid(),
       AccountId = request.AccountId,
       StrategyVersionId = strategyInfo?.StrategyVersionId,
-      Direction = Enum.Parse<TradeDirection>(request.Direction),
+      Direction = resolvedDirection,
       OpenedAt = request.OpenedAt,
       ClosedAt = request.ClosedAt,
       Symbol = request.Symbol.Trim(),
@@ -335,7 +346,17 @@ public sealed class TradesController : ControllerBase
       trade.StrategyVersionId = strategyInfo.StrategyVersionId;
     }
 
-    trade.Direction = Enum.Parse<TradeDirection>(request.Direction);
+    if (!Enum.TryParse<TradeDirection>(request.Direction, ignoreCase: true, out var updatedDirection))
+    {
+      return BadRequest(new { message = $"Invalid direction '{request.Direction}'. Valid values: {string.Join(", ", Enum.GetNames<TradeDirection>())}" });
+    }
+
+    if (!Enum.TryParse<TradeStatus>(request.Status, ignoreCase: true, out var updatedStatus))
+    {
+      return BadRequest(new { message = $"Invalid status '{request.Status}'. Valid values: {string.Join(", ", Enum.GetNames<TradeStatus>())}" });
+    }
+
+    trade.Direction = updatedDirection;
     trade.OpenedAt = request.OpenedAt;
     trade.ClosedAt = request.ClosedAt;
     trade.Symbol = request.Symbol.Trim();
@@ -346,7 +367,7 @@ public sealed class TradesController : ControllerBase
     trade.Pnl = request.Pnl;
     trade.Tags = request.Tags;
     trade.Notes = request.Notes?.Trim();
-    trade.Status = Enum.Parse<TradeStatus>(request.Status);
+    trade.Status = updatedStatus;
     trade.UpdatedAt = DateTime.UtcNow;
 
     await _context.SaveChangesAsync();

--- a/apps/api/Invenet.Api/Program.cs
+++ b/apps/api/Invenet.Api/Program.cs
@@ -27,7 +27,7 @@ builder.Services.AddCors(options =>
     policy
           .WithOrigins(allowedOrigins)
           .AllowAnyHeader()
-          .AllowAnyMethod();
+          .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
   });
 });
 
@@ -38,6 +38,8 @@ builder.Services.AddProblemDetails();
 builder.Services.AddRateLimiter(options =>
 {
   options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+  // Auth endpoints: stricter limit by IP
   options.AddPolicy("auth", httpContext =>
     RateLimitPartition.GetFixedWindowLimiter(
       partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
@@ -45,6 +47,19 @@ builder.Services.AddRateLimiter(options =>
       {
         Window = TimeSpan.FromMinutes(1),
         PermitLimit = 10,
+        QueueLimit = 0
+      }));
+
+  // Global limit: 300 req/min per authenticated user, fallback to IP
+  options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+    RateLimitPartition.GetFixedWindowLimiter(
+      partitionKey: httpContext.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                   ?? httpContext.Connection.RemoteIpAddress?.ToString()
+                   ?? "unknown",
+      factory: _ => new FixedWindowRateLimiterOptions
+      {
+        Window = TimeSpan.FromMinutes(1),
+        PermitLimit = 300,
         QueueLimit = 0
       }));
 });
@@ -84,6 +99,15 @@ else
   app.UseHsts();
   app.UseHttpsRedirection();
 }
+
+app.Use(async (context, next) =>
+{
+  context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+  context.Response.Headers.Append("X-Frame-Options", "DENY");
+  context.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
+  context.Response.Headers.Append("Permissions-Policy", "geolocation=(), camera=(), microphone=()");
+  await next();
+});
 
 app.UseCors();
 

--- a/apps/api/Invenet.Api/appsettings.json
+++ b/apps/api/Invenet.Api/appsettings.json
@@ -7,19 +7,19 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=4500;Database=invenetdb;Username=postgres;Password=mysecretpassword"
+    "DefaultConnection": "SET_VIA_ENVIRONMENT"
   },
   "Jwt": {
     "Issuer": "Invenet.Api",
     "Audience": "Invenet.Api",
-    "Key": "CHANGE_ME_USE_A_LONG_RANDOM_SECRET_AT_LEAST_32_CHARS",
+    "Key": "SET_VIA_ENVIRONMENT",
     "AccessTokenMinutes": 60,
     "RefreshTokenDays": 1,
     "RememberMeRefreshTokenDays": 7
   },
   "SendGrid": {
     "ApiKey": "",
-    "FromEmail": "gaston.saavedra@me.com",
+    "FromEmail": "noreply@yourdomain.com",
     "FromName": "Invenet"
   },
   "Cors": {


### PR DESCRIPTION
- Remove hardcoded DB password, JWT key, and personal email from
  appsettings.json; all sensitive values now read from environment
  variables or user secrets
- Add .env.example documenting every required configuration key
- Add security response headers middleware (X-Content-Type-Options,
  X-Frame-Options, Referrer-Policy, Permissions-Policy)
- Replace AllowAnyMethod() with explicit method whitelist on CORS policy
- Add global rate limiter (300 req/min per user, fallback to IP)
  alongside the existing auth-specific limiter (10 req/min by IP)
- Replace unsafe Enum.Parse<T> calls in TradesController Create and
  Update actions with Enum.TryParse + descriptive 400 responses

https://claude.ai/code/session_01SmZrNHKqAwLVbKDpz5eqHu