### PR TITLE
fix: improve frontend code quality across libs and apps

### DIFF
--- a/libs/account/data-access/src/lib/accounts.store.ts
+++ b/libs/account/data-access/src/lib/accounts.store.ts
@@ -66,7 +66,6 @@ export const AccountsStore = signalStore(
               });
             }),
             catchError((error: Error) => {
-              console.error('Error loading accounts:', error);
               patchState(store, {
                 isLoading: false,
                 error: error.message || 'Failed to load accounts',

--- a/libs/auth/feature/src/lib/forgot-password/forgot-password.component.ts
+++ b/libs/auth/feature/src/lib/forgot-password/forgot-password.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -132,6 +132,7 @@ import { AuthService } from '@invenet/auth-data-access';
       }
     `,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ForgotPasswordComponent {
   private readonly authService = inject(AuthService);

--- a/libs/auth/feature/src/lib/login/login.component.ts
+++ b/libs/auth/feature/src/lib/login/login.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -28,6 +28,7 @@ import { AuthService } from '@invenet/auth-data-access';
   ],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LoginComponent {
   private readonly authService = inject(AuthService);
@@ -61,7 +62,6 @@ export class LoginComponent {
         void this.router.navigateByUrl('/');
       },
       error: () => {
-        console.error('Login failed');
         this.isLoading.set(false);
         this.errorMessage = 'Invalid email or password.';
       },

--- a/libs/auth/feature/src/lib/register/register.component.html
+++ b/libs/auth/feature/src/lib/register/register.component.html
@@ -1,3 +1,4 @@
+<p-toast></p-toast>
 <div class="page-center">
   <p-card class="auth-card" header="Create your account">
     <form class="auth-form" [formGroup]="form" (ngSubmit)="submit()">

--- a/libs/auth/feature/src/lib/register/register.component.ts
+++ b/libs/auth/feature/src/lib/register/register.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -14,6 +14,8 @@ import { FloatLabelModule } from 'primeng/floatlabel';
 import { InputTextModule } from 'primeng/inputtext';
 import { MessageModule } from 'primeng/message';
 import { PasswordModule } from 'primeng/password';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
 import { AuthService } from '@invenet/auth-data-access';
 
 function matchPasswords(control: AbstractControl): ValidationErrors | null {
@@ -40,14 +42,18 @@ function matchPasswords(control: AbstractControl): ValidationErrors | null {
     InputTextModule,
     MessageModule,
     PasswordModule,
+    ToastModule,
   ],
+  providers: [MessageService],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RegisterComponent {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   private readonly fb = inject(FormBuilder).nonNullable;
+  private readonly messageService = inject(MessageService);
 
   readonly form = this.fb.group(
     {
@@ -92,15 +98,17 @@ export class RegisterComponent {
           this.isLoading.set(false);
           this.errorMessage = '';
           this.errorDetails = [];
-          // Show success message and redirect to login
-          alert(
-            'Registration successful! Please check your email to verify your account.',
-          );
-          void this.router.navigateByUrl('/auth/login');
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Registration Successful',
+            detail:
+              'Please check your email to verify your account.',
+            life: 5000,
+          });
+          setTimeout(() => void this.router.navigateByUrl('/auth/login'), 2000);
         },
         error: (error) => {
           this.isLoading.set(false);
-          console.error('Registration failed:', error);
           this.errorMessage =
             error?.error?.message ||
             'Unable to create account. Check your details.';

--- a/libs/auth/feature/src/lib/reset-password/reset-password.component.ts
+++ b/libs/auth/feature/src/lib/reset-password/reset-password.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -168,6 +168,7 @@ function matchPasswords(control: AbstractControl): ValidationErrors | null {
       }
     `,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ResetPasswordComponent implements OnInit {
   private readonly authService = inject(AuthService);

--- a/libs/auth/feature/src/lib/verify-email/verify-email.component.ts
+++ b/libs/auth/feature/src/lib/verify-email/verify-email.component.ts
@@ -1,16 +1,20 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { MessageModule } from 'primeng/message';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
 import { AuthService } from '@invenet/auth-data-access';
 
 @Component({
   selector: 'lib-verify-email',
   standalone: true,
-  imports: [CardModule, MessageModule, ButtonModule, ProgressSpinnerModule],
+  imports: [CardModule, MessageModule, ButtonModule, ProgressSpinnerModule, ToastModule],
+  providers: [MessageService],
   template: `
+    <p-toast></p-toast>
     <div class="page-center">
       <p-card class="auth-card" header="Email Verification">
         @if (isLoading()) {
@@ -74,11 +78,13 @@ import { AuthService } from '@invenet/auth-data-access';
       }
     `,
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VerifyEmailComponent implements OnInit {
   private readonly authService = inject(AuthService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly messageService = inject(MessageService);
 
   isLoading = signal(true);
   isSuccess = signal(false);
@@ -124,11 +130,21 @@ export class VerifyEmailComponent implements OnInit {
     this.authService.resendVerification(this.email()).subscribe({
       next: () => {
         this.isResending.set(false);
-        alert('Verification email sent! Please check your inbox.');
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Email Sent',
+          detail: 'Verification email sent! Please check your inbox.',
+          life: 5000,
+        });
       },
       error: () => {
         this.isResending.set(false);
-        alert('Failed to resend verification email. Please try again.');
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Failed to resend verification email. Please try again.',
+          life: 5000,
+        });
       },
     });
   }

--- a/libs/shared/ui-layout/src/lib/app.menuitem.ts
+++ b/libs/shared/ui-layout/src/lib/app.menuitem.ts
@@ -1,4 +1,5 @@
 import { Component, computed, inject, input, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { RippleModule } from 'primeng/ripple';
@@ -158,7 +159,10 @@ export class AppMenuitem {
 
   constructor() {
     this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntilDestroyed(),
+      )
       .subscribe(() => {
         if (this.item()?.routerLink) {
           this.updateActiveStateFromRoute();

--- a/libs/shared/ui-layout/src/lib/app.topbar.ts
+++ b/libs/shared/ui-layout/src/lib/app.topbar.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MenuItem } from 'primeng/api';
 import { Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -30,6 +31,7 @@ import { LayoutService } from './service/layout.service';
       <button
         class="layout-menu-button layout-topbar-action"
         (click)="layoutService.onMenuToggle()"
+        aria-label="Toggle menu"
       >
         <i class="pi pi-bars"></i>
       </button>
@@ -45,6 +47,7 @@ import { LayoutService } from './service/layout.service';
           type="button"
           class="layout-topbar-action"
           (click)="toggleDarkMode()"
+          aria-label="Toggle dark mode"
         >
           <i
             [ngClass]="{
@@ -57,6 +60,7 @@ import { LayoutService } from './service/layout.service';
         <div class="relative">
           <button
             class="layout-topbar-action layout-topbar-action-highlight"
+            aria-label="Theme configurator"
             pStyleClass="@next"
             enterFromClass="hidden"
             enterActiveClass="animate-scalein"
@@ -72,6 +76,7 @@ import { LayoutService } from './service/layout.service';
 
       <button
         class="layout-topbar-menu-button layout-topbar-action"
+        aria-label="More actions"
         pStyleClass="@next"
         enterFromClass="hidden"
         enterActiveClass="animate-scalein"
@@ -155,6 +160,7 @@ export class AppTopbar {
   private readonly router = inject(Router);
   private readonly accountsStore = inject(AccountsStore);
   private readonly activeAccountStore = inject(ActiveAccountStore);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly accountOptions = this.accountsStore.activeAccounts;
   readonly activeAccountId = this.activeAccountStore.activeAccountId;
@@ -178,13 +184,16 @@ export class AppTopbar {
   }
 
   onLogout() {
-    this.authService.logout().subscribe({
-      next: () => void this.router.navigateByUrl('/auth/login'),
-      error: () => {
-        this.authService.clearTokens();
-        void this.router.navigateByUrl('/auth/login');
-      },
-    });
+    this.authService
+      .logout()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => void this.router.navigateByUrl('/auth/login'),
+        error: () => {
+          this.authService.clearTokens();
+          void this.router.navigateByUrl('/auth/login');
+        },
+      });
   }
 
   onQuickLogTrade(): void {

--- a/libs/shared/util-auth/src/lib/shared-util-auth/auth.interceptor.spec.ts
+++ b/libs/shared/util-auth/src/lib/shared-util-auth/auth.interceptor.spec.ts
@@ -95,6 +95,6 @@ describe('authInterceptor', () => {
     req.flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
 
     expect(authService.cleared).toBe(true);
-    expect(router.navigatedTo).toBe('/login');
+    expect(router.navigatedTo).toBe('/auth/login');
   });
 });

--- a/libs/shared/util-auth/src/lib/shared-util-auth/auth.interceptor.ts
+++ b/libs/shared/util-auth/src/lib/shared-util-auth/auth.interceptor.ts
@@ -82,7 +82,7 @@ function handleError(
 ) {
   if (error.status === 401) {
     authService.clearTokens();
-    router.navigateByUrl('/login');
+    router.navigateByUrl('/auth/login');
   }
   return throwError(() => error);
 }

--- a/libs/strategy/feature/src/lib/strategy-list-page/strategy-list.page.ts
+++ b/libs/strategy/feature/src/lib/strategy-list-page/strategy-list.page.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -33,6 +33,7 @@ import { StrategyListComponent } from '@invenet/strategy-ui';
       ></lib-strategy-list>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StrategyListPage {
   private readonly store = inject(StrategiesStore);

--- a/libs/strategy/ui/src/lib/strategy-list/strategy-list.component.ts
+++ b/libs/strategy/ui/src/lib/strategy-list/strategy-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
@@ -21,6 +21,7 @@ import type { StrategyListItem } from '@invenet/strategy-data-access';
   ],
   templateUrl: './strategy-list.component.html',
   styleUrls: ['./strategy-list.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StrategyListComponent {
   strategies = input<StrategyListItem[]>([]);

--- a/libs/trade/data-access/src/lib/trade-data-access/models/trade.model.ts
+++ b/libs/trade/data-access/src/lib/trade-data-access/models/trade.model.ts
@@ -43,7 +43,7 @@ export interface CreateTradeRequest {
   accountId: string;
   strategyId?: string;
   strategyVersionId?: string;
-  direction: TradeDirection | string;
+  direction: TradeDirection;
   openedAt: string;
   symbol: string;
   entryPrice: number;
@@ -54,13 +54,13 @@ export interface CreateTradeRequest {
   pnl?: number;
   tags?: string[];
   notes?: string;
-  status?: TradeStatus | string;
+  status?: TradeStatus;
 }
 
 export interface UpdateTradeRequest {
   strategyId?: string;
   strategyVersionId?: string;
-  direction: TradeDirection | string;
+  direction: TradeDirection;
   openedAt: string;
   symbol: string;
   entryPrice: number;
@@ -71,7 +71,7 @@ export interface UpdateTradeRequest {
   pnl?: number;
   tags?: string[];
   notes?: string;
-  status: TradeStatus | string;
+  status: TradeStatus;
 }
 export type TradeDetail = Trade;
 export type TradeResponse = Trade;

--- a/libs/trade/feature/src/lib/trade-detail-page/trade-detail.page.ts
+++ b/libs/trade/feature/src/lib/trade-detail-page/trade-detail.page.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -32,6 +32,7 @@ import { TradeDetailComponent } from '@invenet/trade-ui';
       ></lib-trade-detail>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TradeDetailPage {
   private readonly store = inject(TradesStore);

--- a/libs/trade/feature/src/lib/trade-edit-page/trade-edit.page.ts
+++ b/libs/trade/feature/src/lib/trade-edit-page/trade-edit.page.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MessageService } from 'primeng/api';
@@ -41,6 +41,7 @@ import { TradeFormComponent } from '@invenet/trade-ui';
       ></lib-trade-form>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TradeEditPage {
   private readonly store = inject(TradesStore);
@@ -82,8 +83,6 @@ export class TradeEditPage {
   }
 
   onSaveTrade(payload: CreateTradeRequest | UpdateTradeRequest): void {
-    console.log('Saving trade with payload:', payload);
-
     if (!this.tradeId) return;
     this.store.updateTrade({
       id: this.tradeId,

--- a/libs/trade/feature/src/lib/trade-list-page/trade-list.page.ts
+++ b/libs/trade/feature/src/lib/trade-list-page/trade-list.page.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -43,6 +43,7 @@ import { TradeListComponent } from '@invenet/trade-ui';
       ></lib-trade-list>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TradeListPage {
   private readonly store = inject(TradesStore);

--- a/libs/trade/feature/src/lib/trade-new-page/trade-new.page.ts
+++ b/libs/trade/feature/src/lib/trade-new-page/trade-new.page.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MessageService } from 'primeng/api';
@@ -40,6 +40,7 @@ import { TradeFormComponent } from '@invenet/trade-ui';
       ></lib-trade-form>
     </div>
   `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TradeNewPage {
   private readonly store = inject(TradesStore);

--- a/libs/trade/ui/src/lib/quick-trade-modal/quick-trade-modal.component.ts
+++ b/libs/trade/ui/src/lib/quick-trade-modal/quick-trade-modal.component.ts
@@ -8,9 +8,8 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { Subject, switchMap, filter, EMPTY, catchError } from 'rxjs';
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -23,6 +22,7 @@ import {
   ActiveAccountStore,
 } from '@invenet/account-data-access';
 import {
+  GetStrategyResponse,
   StrategiesApiService,
   StrategiesStore,
 } from '@invenet/strategy-data-access';
@@ -79,40 +79,36 @@ export class QuickTradeModalComponent {
     quantity: [null as number | null],
   });
 
-  readonly currentVersionNumber = signal<number | null>(null);
-  readonly currentVersionId = signal<string | null>(null);
-  readonly strategyVersionError = signal<string | null>(null);
+  readonly selectedStrategyId = signal<string | null>(null);
 
-  private readonly strategyChange$ = new Subject<string | null>();
+  private readonly strategyResource = rxResource({
+    params: () => this.selectedStrategyId() || undefined,
+    stream: ({ params: strategyId }: { params: string }) =>
+      this.strategiesApiService.get(strategyId),
+  });
+
+  readonly currentVersionId = computed(() => {
+    const strategy = this.strategyResource.value();
+    return strategy?.currentVersion?.id ?? null;
+  });
+
+  readonly currentVersionNumber = computed(() => {
+    const strategy = this.strategyResource.value();
+    return strategy?.currentVersion?.versionNumber ?? null;
+  });
+
+  readonly strategyVersionError = computed(() => {
+    if (this.strategyResource.error()) {
+      return 'Failed to resolve strategy version';
+    }
+    const strategy = this.strategyResource.value();
+    if (strategy && !strategy.currentVersion) {
+      return 'This strategy has no published version';
+    }
+    return null;
+  });
 
   constructor() {
-    this.strategyChange$
-      .pipe(
-        filter((id): id is string => !!id),
-        switchMap((strategyId) =>
-          this.strategiesApiService.get(strategyId).pipe(
-            catchError(() => {
-              this.strategyVersionError.set(
-                'Failed to resolve strategy version',
-              );
-              return EMPTY;
-            }),
-          ),
-        ),
-        takeUntilDestroyed(),
-      )
-      .subscribe((strategy) => {
-        const version = strategy.currentVersion;
-        if (!version) {
-          this.strategyVersionError.set(
-            'This strategy has no published version',
-          );
-          return;
-        }
-        this.currentVersionId.set(version.id);
-        this.currentVersionNumber.set(version.versionNumber);
-      });
-
     effect(() => {
       if (!this.isOpen()) {
         return;
@@ -131,10 +127,7 @@ export class QuickTradeModalComponent {
   }
 
   onStrategyChange(strategyId: string | null): void {
-    this.currentVersionId.set(null);
-    this.currentVersionNumber.set(null);
-    this.strategyVersionError.set(null);
-    this.strategyChange$.next(strategyId);
+    this.selectedStrategyId.set(strategyId);
   }
 
   submitQuickTrade(): void {
@@ -192,8 +185,6 @@ export class QuickTradeModalComponent {
       entryPrice: null,
       quantity: null,
     });
-    this.currentVersionId.set(null);
-    this.currentVersionNumber.set(null);
-    this.strategyVersionError.set(null);
+    this.selectedStrategyId.set(null);
   }
 }

--- a/libs/trade/ui/src/lib/quick-trade-modal/quick-trade-modal.component.ts
+++ b/libs/trade/ui/src/lib/quick-trade-modal/quick-trade-modal.component.ts
@@ -3,11 +3,14 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Subject, switchMap, filter, EMPTY, catchError } from 'rxjs';
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -57,6 +60,7 @@ export class QuickTradeModalComponent {
   private readonly strategiesApiService = inject(StrategiesApiService);
   private readonly tradesApiService = inject(TradesApiService);
   private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly isOpen = this.tradesStore.isQuickModalOpen;
   readonly isLoading = this.tradesStore.isLoading;
@@ -79,7 +83,36 @@ export class QuickTradeModalComponent {
   readonly currentVersionId = signal<string | null>(null);
   readonly strategyVersionError = signal<string | null>(null);
 
+  private readonly strategyChange$ = new Subject<string | null>();
+
   constructor() {
+    this.strategyChange$
+      .pipe(
+        filter((id): id is string => !!id),
+        switchMap((strategyId) =>
+          this.strategiesApiService.get(strategyId).pipe(
+            catchError(() => {
+              this.strategyVersionError.set(
+                'Failed to resolve strategy version',
+              );
+              return EMPTY;
+            }),
+          ),
+        ),
+        takeUntilDestroyed(),
+      )
+      .subscribe((strategy) => {
+        const version = strategy.currentVersion;
+        if (!version) {
+          this.strategyVersionError.set(
+            'This strategy has no published version',
+          );
+          return;
+        }
+        this.currentVersionId.set(version.id);
+        this.currentVersionNumber.set(version.versionNumber);
+      });
+
     effect(() => {
       if (!this.isOpen()) {
         return;
@@ -101,27 +134,7 @@ export class QuickTradeModalComponent {
     this.currentVersionId.set(null);
     this.currentVersionNumber.set(null);
     this.strategyVersionError.set(null);
-
-    if (!strategyId) {
-      return;
-    }
-
-    this.strategiesApiService.get(strategyId).subscribe({
-      next: (strategy) => {
-        const version = strategy.currentVersion;
-        if (!version) {
-          this.strategyVersionError.set(
-            'This strategy has no published version',
-          );
-          return;
-        }
-        this.currentVersionId.set(version.id);
-        this.currentVersionNumber.set(version.versionNumber);
-      },
-      error: () => {
-        this.strategyVersionError.set('Failed to resolve strategy version');
-      },
-    });
+    this.strategyChange$.next(strategyId);
   }
 
   submitQuickTrade(): void {
@@ -142,6 +155,7 @@ export class QuickTradeModalComponent {
         quantity: value.quantity ?? undefined,
         status: 'Open',
       })
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
           this.messageService.add({

--- a/libs/trade/ui/src/lib/trade-form/trade-form.component.ts
+++ b/libs/trade/ui/src/lib/trade-form/trade-form.component.ts
@@ -19,6 +19,8 @@ import { StrategiesStore } from '@invenet/strategy-data-access';
 import {
   CreateTradeRequest,
   Trade,
+  TradeDirection,
+  TradeStatus,
   UpdateTradeRequest,
 } from '@invenet/trade-data-access';
 
@@ -93,7 +95,6 @@ export class TradeFormComponent {
 
   constructor() {
     effect(() => {
-      console.log('Trade input changed:', this.trade());
       const t = this.trade();
       if (t && this.mode() === 'edit') {
         this.initialStrategyId = t.strategyId;
@@ -140,8 +141,6 @@ export class TradeFormComponent {
       const status = this.form.controls.status.value;
       const exitPrice = this.form.controls.exitPrice;
       const closedAt = this.form.controls.closedAt;
-
-      console.log('Status changed to:', status);
 
       if (status === 'Closed') {
         exitPrice.setValidators([Validators.required, Validators.min(0.0001)]);
@@ -223,11 +222,14 @@ export class TradeFormComponent {
       .map((value) => value.trim())
       .filter((value) => value.length > 0);
 
+    const direction = (raw.direction ?? 'Long') as TradeDirection;
+    const status = (raw.status ?? 'Open') as TradeStatus;
+
     if (this.isEditMode) {
       const request: UpdateTradeRequest = {
         strategyId: raw.strategyId ?? undefined,
         strategyVersionId: raw.strategyVersionId ?? undefined,
-        direction: raw.direction ?? 'Long',
+        direction,
         openedAt,
         closedAt,
         symbol: (raw.symbol ?? '').toUpperCase(),
@@ -238,7 +240,7 @@ export class TradeFormComponent {
         pnl: raw.pnl ?? undefined,
         tags,
         notes: raw.notes ?? undefined,
-        status: raw.status ?? 'Open',
+        status,
       };
       this.save.emit(request);
       return;
@@ -248,7 +250,7 @@ export class TradeFormComponent {
       accountId: raw.accountId ?? '',
       strategyId: raw.strategyId ?? undefined,
       strategyVersionId: raw.strategyVersionId ?? undefined,
-      direction: raw.direction ?? 'Long',
+      direction,
       openedAt,
       closedAt,
       symbol: (raw.symbol ?? '').toUpperCase(),
@@ -259,7 +261,7 @@ export class TradeFormComponent {
       pnl: raw.pnl ?? undefined,
       tags,
       notes: raw.notes ?? undefined,
-      status: raw.status ?? 'Open',
+      status,
     };
     this.save.emit(request);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@invenet/source",
+  "name": "invenet-workspace",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@invenet/source",
+      "name": "invenet-workspace",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- Fix auth interceptor redirecting to wrong path (/login -> /auth/login)
- Fix memory leaks by adding takeUntilDestroyed to observable subscriptions
- Fix race condition in quick-trade modal using switchMap for strategy lookups
- Add ChangeDetectionStrategy.OnPush to 11 components for better performance
- Replace browser alert() calls with PrimeNG MessageService toasts
- Enforce strict TypeScript types on TradeDirection/TradeStatus (remove | string)
- Remove debug console.log/console.error statements from production code
- Add aria-labels to icon-only buttons in topbar for accessibility

https://claude.ai/code/session_01RkJSqD9uVCWQJFNumHRCme